### PR TITLE
config_netmiko_and_paramiko_file

### DIFF
--- a/netmikolab.py
+++ b/netmikolab.py
@@ -13,6 +13,13 @@ devices = {
         "network 172.31.13.0 0.0.0.255 area 0",
         "network 10.13.0.0 0.0.255.255 area 0",
         "exit"
+        # add extended ACL
+        "access-list 101 permit 172.31.13.0 0.0.0.255",
+        "access-list 101 permit 10.13.3.5 0.0.0.0",
+        "line vty 0 4",
+        "access-class 101 in",
+        "transport input telnet ssh",
+        "end"
     ]),
     'R2': ('172.31.13.5', [
         "int Loopback0", 
@@ -29,6 +36,13 @@ devices = {
         "access-list 1 permit 172.31.13.0 0.0.0.255",
         "access-list 1 permit 10.13.0.0 0.0.255.255",
         "ip nat inside source list 1 interface GigabitEthernet0/3 vrf control-data overload"
+        # add extended ACL
+        "access-list 101 permit 172.31.13.0 0.0.0.255",
+        "access-list 101 permit 10.13.3.5 0.0.0.0",
+        "line vty 0 4",
+        "access-class 101 in",
+        "transport input telnet ssh",
+        "end"
     ]),
     'S1': ('172.31.13.3', [
         "vlan 101", 
@@ -40,6 +54,13 @@ devices = {
         "int gi 1/1", "switchport mode access", "switchport access vlan 101",
         "no shut",
         "exit"
+        # add extended ACL
+        "access-list 101 permit 172.31.13.0 0.0.0.255",
+        "access-list 101 permit 10.13.3.5 0.0.0.0",
+        "line vty 0 4",
+        "access-class 101 in",
+        "transport input telnet ssh",
+        "end"
     ])
 }
 

--- a/paramikolab.py
+++ b/paramikolab.py
@@ -6,14 +6,14 @@ ssh = paramiko.SSHClient()
 ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
 network = [
-    "172.31.13.1",
-    "172.31.13.2",
-    "172.31.13.3",
-    "172.31.13.4",
-    "172.31.13.5"
+    ("R0", "172.31.13.1"),
+    ("R1", "172.31.13.2"),
+    ("R2", "172.31.13.3"),
+    ("S0", "172.31.13.4"),
+    ("S1", "172.31.13.5"),
 ]
 
-for index, ip in enumerate(network):
+for index, (name, ip) in enumerate(network):
     try:
         ssh.connect(
             hostname=ip,
@@ -30,9 +30,9 @@ for index, ip in enumerate(network):
 
         if index == 0:
             stdin, stdout, stderr = ssh.exec_command("show running-config")
-            with open('R0_running_config', 'w') as file:
+            with open(f'{name}_running_config', 'w') as file:
                 file.write(stdout.read().decode())
-            print("Saving R0 running config")
+            print(f"Saving {name} running config")
 
         ssh.close()
 


### PR DESCRIPTION
I add ACL for telnet and ssh on netmikolab.py and changed paramikolab.py what write running-config of  R0 only to write running-config all devices